### PR TITLE
Add image parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,14 @@ Without `bash -c`, the environment variables would be evaluated before `with-con
 
 ### Options
 
-- `--version`: Specify the Connect version (default: release). Use "latest" or "release" for the most recent version, or specify a version like "2024.08.0", or a known docker tag.
-- `--license`: Path to license file (default: ./rstudio-connect.lic). This file must exist and be a valid Connect license.
-- `--config`: Path to optional rstudio-connect.gcfg configuration file
-- `--port`: Port to map the Connect container to (default: 3939). Allows running multiple Connect instances simultaneously.
-- `-e`, `--env`: Environment variables to pass to the Docker container (format: KEY=VALUE). Can be specified multiple times.
+| Option        | Default                 | Description                                                                                                          |
+|---------------|-------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `--version`   | `release`               | Posit Connect version. Use "latest" or "release" for the most recent version, or specify a version like "2024.08.0". |
+| `--license`   | `./rstudio-connect.lic` | Path to license file. This file must exist and be a valid Connect license.                                           |
+| `--image`     |                         | Container image to use, including tag (e.g., `posit/connect:2025.12.0`). Overrides `--version`.                      |
+| `--config`    |                         | Path to optional rstudio-connect.gcfg configuration file                                                             |
+| `--port`      | `3939`                  | Port to map the Connect container to. Allows running multiple Connect instances simultaneously.                      |
+| `-e`, `--env` |                         | Environment variables to pass to the Docker container (format: KEY=VALUE). Can be specified multiple times.          |
 
 Example:
 
@@ -88,6 +91,23 @@ If you need env vars that are useful for the command running after `--`, just se
 This project contains a GitHub Action for use in CI/CD workflows. Use the `@v1` tag to get the latest stable version, or `@main` for the development version.
 
 You will need to store your Posit Connect license file as a GitHub secret (e.g., `CONNECT_LICENSE_FILE`).
+
+### GitHub Action Inputs
+
+The GitHub Action supports the following inputs:
+
+| Input         | Required | Default   | Description                                                                                   |
+|---------------|----------|-----------|-----------------------------------------------------------------------------------------------|
+| `license`     | Yes      |           | Posit Connect license file contents (store as a GitHub secret)                                |
+| `version`     | No       | `release` | Posit Connect version                                                                         |
+| `image`       | No       |           | Container image to use, including tag (e.g., `posit/connect:2025.12.0`). Overrides `version`. |
+| `config-file` | No       |           | Path to rstudio-connect.gcfg configuration file                                               |
+| `port`        | No       | `3939`    | Port to map the Connect container to                                                          |
+| `quiet`       | No       | `false`   | Suppress progress indicators during image pull                                                |
+| `env`         | No       |           | Environment variables to pass to Docker container (one per line, format: KEY=VALUE)           |
+| `command`     | Yes      |           | Command to run against Connect                                                                |
+
+### Deploy a Connect Manifest
 
 ```yaml
 name: Integration tests with Connect
@@ -139,19 +159,7 @@ The `$CONNECT_API_KEY` and `$CONNECT_SERVER` environment variables are available
     command: 'curl -f -H "Authorization: Key $CONNECT_API_KEY" $CONNECT_SERVER/__api__/v1/content'
 ```
 
-### GitHub Action Options
-
-The GitHub Action supports the following inputs:
-
-- `license` (required): Posit Connect license key (store as a GitHub secret)
-- `version` (optional): Posit Connect version (default: release)
-- `config-file` (optional): Path to rstudio-connect.gcfg configuration file
-- `port` (optional): Port to map the Connect container to (default: 3939)
-- `quiet` (optional): Suppress progress indicators during image pull (default: false)
-- `env` (optional): Environment variables to pass to Docker container (one per line, format: KEY=VALUE)
-- `command` (required): Command to run against Connect
-
-Example with environment variables:
+### Set Environment Variables
 
 ```yaml
 - name: Test deployment with custom env vars
@@ -162,6 +170,17 @@ Example with environment variables:
     env: |
       MY_VAR=value
       ANOTHER_VAR=123
+    command: rsconnect deploy manifest .
+```
+
+### Specify a Custom Container Image
+
+```yaml
+- name: Test deployment with custom image
+  uses: posit-dev/with-connect@v1
+  with:
+    image: rstudio/rstudio-connect:jammy-2025.09.0
+    license: ${{ secrets.CONNECT_LICENSE_FILE }}
     command: rsconnect deploy manifest .
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Deploy to Posit Connect'
 description: 'Deploy content to Posit Connect using with-connect'
 inputs:
   license:
-    description: 'Posit Connect license key'
+    description: 'Posit Connect license file contents'
     required: true
   version:
     description: 'Posit Connect version to use'
@@ -10,6 +10,9 @@ inputs:
     default: 'release'
   config-file:
     description: 'Path to optional rstudio-connect.gcfg configuration file'
+    required: false
+  image:
+    description: 'Container image to use for Posit Connect'
     required: false
   quiet:
     description: 'Suppress progress indicators during image pull'
@@ -46,6 +49,9 @@ runs:
         ARGS="--version ${{ inputs.version }} --port ${{ inputs.port }}"
         if [ -n "${{ inputs.config-file }}" ]; then
           ARGS="$ARGS --config ${{ inputs.config-file }}"
+        fi
+        if [ -n "${{ inputs.image }}" ]; then
+          ARGS="$ARGS --image ${{ inputs.image }}"
         fi
         if [ "${{ inputs.quiet }}" = "true" ]; then
           ARGS="$ARGS --quiet"

--- a/test_main.py
+++ b/test_main.py
@@ -207,34 +207,23 @@ def test_image_and_version_exclusive():
         )
 
         assert result.returncode == 1
-        assert "Cannot specify both --image and --version" in result.stderr
+        assert "Cannot specify both 'image' and 'version'" in result.stderr
     finally:
         os.unlink(license_file)
 
 
 def test_image_without_tag():
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".lic", delete=False) as f:
-        license_file = f.name
+    base_image, tag, used_default = main.parse_image_spec("rstudio/rstudio-connect")
+    assert base_image == "rstudio/rstudio-connect"
+    assert tag == "latest"
+    assert used_default is True
 
-    try:
-        result = subprocess.run(
-            [
-                sys.executable,
-                "main.py",
-                "--license",
-                license_file,
-                "--image",
-                "rstudio/rstudio-connect",
-            ],
-            capture_output=True,
-            text=True,
-        )
 
-        assert result.returncode == 1
-        assert "Invalid image format" in result.stderr
-        assert "Image must include a tag" in result.stderr
-    finally:
-        os.unlink(license_file)
+def test_image_with_tag():
+    base_image, tag, used_default = main.parse_image_spec("rstudio/rstudio-connect:jammy-2025.09.0")
+    assert base_image == "rstudio/rstudio-connect"
+    assert tag == "jammy-2025.09.0"
+    assert used_default is False
 
 
 if __name__ == "__main__":
@@ -258,6 +247,9 @@ if __name__ == "__main__":
 
     test_image_without_tag()
     print("✓ test_image_without_tag passed")
+
+    test_image_with_tag()
+    print("✓ test_image_with_tag passed")
 
     test_get_docker_tag_latest()
     print("✓ test_get_docker_tag_latest passed")

--- a/test_main.py
+++ b/test_main.py
@@ -186,6 +186,57 @@ def test_custom_port():
     assert "default: 3939" in result.stdout
 
 
+def test_image_and_version_exclusive():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lic", delete=False) as f:
+        license_file = f.name
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "main.py",
+                "--license",
+                license_file,
+                "--image",
+                "rstudio/rstudio-connect:jammy-2025.09.0",
+                "--version",
+                "2024.08.0",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 1
+        assert "Cannot specify both --image and --version" in result.stderr
+    finally:
+        os.unlink(license_file)
+
+
+def test_image_without_tag():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".lic", delete=False) as f:
+        license_file = f.name
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "main.py",
+                "--license",
+                license_file,
+                "--image",
+                "rstudio/rstudio-connect",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 1
+        assert "Invalid image format" in result.stderr
+        assert "Image must include a tag" in result.stderr
+    finally:
+        os.unlink(license_file)
+
+
 if __name__ == "__main__":
     test_license_file_not_exists()
     print("✓ test_license_file_not_exists passed")
@@ -201,6 +252,12 @@ if __name__ == "__main__":
 
     test_valid_license_http_server_starts()
     print("✓ test_valid_license_http_server_starts passed")
+
+    test_image_and_version_exclusive()
+    print("✓ test_image_and_version_exclusive passed")
+
+    test_image_without_tag()
+    print("✓ test_image_without_tag passed")
 
     test_get_docker_tag_latest()
     print("✓ test_get_docker_tag_latest passed")


### PR DESCRIPTION
Add an image parameter to the action.

This simplifies running a specific image for Connect

The image must be specified with a tag (e.g. `rstudio/rstudio-connect:2025.12.0`) and will override the default `version`.
The script and action will exit with an error if both `image` and `version` are specified.

