### PR TITLE
ci: Switch Connect images to ghcr.io/posit-dev (2026.04 cutover)

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,8 +12,15 @@ from rsconnect.api import RSConnectClient, RSConnectServer
 from rsconnect.json_web_token import TokenGenerator
 
 
-IMAGE = "rstudio/rstudio-connect"
+IMAGE = "ghcr.io/posit-dev/connect"
+PREVIEW_IMAGE = "ghcr.io/posit-dev/connect-preview"
+LEGACY_IMAGE = "rstudio/rstudio-connect"
 VERSION = "release"
+
+# Versions at or after this registry cutover land on ghcr.io/posit-dev.
+# Older versions only exist on the legacy Docker Hub images.
+REGISTRY_CUTOVER_YEAR = 2026
+REGISTRY_CUTOVER_MONTH = 4
 
 
 def parse_args():
@@ -172,41 +179,46 @@ def get_docker_tag(version: str) -> tuple[str, str]:
     """
     Convert a version string to the appropriate Docker image and tag.
 
-    Maps semantic versions to the correct base image and tag based on when
-    Connect switched from bionic (Ubuntu 18.04) to jammy (Ubuntu 22.04).
-    Also maps 'latest'/'release' to 'jammy' since 'latest' is unmaintained.
-    Maps 'preview' to the nightly build image.
+    Versions at or after the registry cutover (2026.04) come from
+    ghcr.io/posit-dev/connect, where the tag is just the version and the
+    image is a multi-arch manifest defaulting to the latest OS variant.
+
+    Older versions continue to resolve against rstudio/rstudio-connect on
+    Docker Hub with the legacy OS-prefixed tags (jammy- for the Ubuntu
+    22.04 era, bionic- for Ubuntu 18.04).
+
+    'latest' / 'release' map to ghcr.io/posit-dev/connect:latest. 'preview'
+    maps to ghcr.io/posit-dev/connect-preview:daily.
 
     Returns:
         tuple[str, str]: (base_image, tag)
     """
     if version == "preview":
-        # Map to nightly preview build
-        return ("rstudio/rstudio-connect-preview", "jammy-daily")
+        return (PREVIEW_IMAGE, "daily")
 
     if version in ("latest", "release"):
-        # For the rstudio/rstudio-connect image, "jammy" is currently used
-        # for the latest stable release. "latest" never gets updated and points
-        # to 2022.08.0, which, aside from being misleading, also does not
-        # have the bootstrap endpoint that this utility relies on.
-        return (IMAGE, "jammy")
+        return (IMAGE, "latest")
 
     parts = version.split(".")
     if len(parts) < 2:
-        return (IMAGE, version)
+        return (LEGACY_IMAGE, version)
 
     try:
         year = int(parts[0])
         month = int(parts[1])
     except ValueError:
-        return (IMAGE, version)
+        return (LEGACY_IMAGE, version)
 
-    if year > 2023 or (year == 2023 and month > 6):
-        return (IMAGE, f"jammy-{version}")
-    elif year > 2022 or (year == 2022 and month >= 9):
-        return (IMAGE, f"bionic-{version}")
-    else:
+    if year > REGISTRY_CUTOVER_YEAR or (
+        year == REGISTRY_CUTOVER_YEAR and month >= REGISTRY_CUTOVER_MONTH
+    ):
         return (IMAGE, version)
+    elif year > 2023 or (year == 2023 and month > 6):
+        return (LEGACY_IMAGE, f"jammy-{version}")
+    elif year > 2022 or (year == 2022 and month >= 9):
+        return (LEGACY_IMAGE, f"bionic-{version}")
+    else:
+        return (LEGACY_IMAGE, version)
 
 
 def main() -> int:

--- a/test_main.py
+++ b/test_main.py
@@ -82,18 +82,27 @@ def test_valid_license_http_server_starts():
 
 
 def test_get_docker_tag_latest():
-    assert main.get_docker_tag("latest") == ("rstudio/rstudio-connect", "jammy")
+    assert main.get_docker_tag("latest") == ("ghcr.io/posit-dev/connect", "latest")
 
 
 def test_get_docker_tag_release():
-    assert main.get_docker_tag("release") == ("rstudio/rstudio-connect", "jammy")
+    assert main.get_docker_tag("release") == ("ghcr.io/posit-dev/connect", "latest")
 
 
 def test_get_docker_tag_preview():
-    assert main.get_docker_tag("preview") == ("rstudio/rstudio-connect-preview", "jammy-daily")
+    assert main.get_docker_tag("preview") == ("ghcr.io/posit-dev/connect-preview", "daily")
+
+
+def test_get_docker_tag_ghcr_version():
+    # 2026.04 and later: ghcr.io/posit-dev/connect with bare version
+    assert main.get_docker_tag("2026.04.0") == ("ghcr.io/posit-dev/connect", "2026.04.0")
+    assert main.get_docker_tag("2026.05.1") == ("ghcr.io/posit-dev/connect", "2026.05.1")
+    assert main.get_docker_tag("2027.01.0") == ("ghcr.io/posit-dev/connect", "2027.01.0")
 
 
 def test_get_docker_tag_jammy_version():
+    # Pre-cutover jammy era (2023.07 - 2026.03): legacy Docker Hub jammy- prefix
+    assert main.get_docker_tag("2026.03.0") == ("rstudio/rstudio-connect", "jammy-2026.03.0")
     assert main.get_docker_tag("2025.09.0") == ("rstudio/rstudio-connect", "jammy-2025.09.0")
     assert main.get_docker_tag("2024.01.0") == ("rstudio/rstudio-connect", "jammy-2024.01.0")
     assert main.get_docker_tag("2023.07.0") == ("rstudio/rstudio-connect", "jammy-2023.07.0")


### PR DESCRIPTION
Switch the Docker image source for Posit Connect to the bakery-built `ghcr.io/posit-dev/connect` images for versions at or after the 2026.04 bakery cutover. Pre-cutover versions stay on the legacy Docker Hub images — those builds don't exist on GHCR.

- `rstudio/rstudio-connect` → `ghcr.io/posit-dev/connect` for `latest`, `release`, and versions ≥ 2026.04
- `rstudio/rstudio-connect-preview:jammy-daily` → `ghcr.io/posit-dev/connect-preview:daily`
- Tag: drop the `jammy-` prefix for GHCR images; the bare-version (or `latest` / `daily`) tag resolves to the bakery primary variant (Ubuntu 24.04 + Standard). OS effectively shifts from 22.04 to 24.04 for new versions.
- Versions 2023.07 – 2026.03 still resolve to `rstudio/rstudio-connect:jammy-<calver>`; the bionic and pre-bionic eras are also unchanged.
- `latest` / `release` map to `ghcr.io/posit-dev/connect:latest` (the floating latest-OS tag bakery publishes).

Tests updated to cover the 2026.03 → 2026.04 boundary and the new `latest` / `daily` tag scheme.