### PR TITLE
ci: Only force linux/amd64 for legacy rstudio/* images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,17 @@ jobs:
         run: uv run test_main.py
 
   test-action:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v5
 
       - name: Test with-connect action (single line)
         uses: ./
         with:
-          version: 2024.08.0
           license: ${{ secrets.CONNECT_LICENSE }}
           # If this were not quoted before running, $CONNECT_API_KEY
           # would evaluate before with-connect defines it.
@@ -41,7 +44,6 @@ jobs:
       - name: Test with-connect action (multiline, different quoting)
         uses: ./
         with:
-          version: 2024.08.0
           license: ${{ secrets.CONNECT_LICENSE }}
           command: |
             set -euo pipefail

--- a/main.py
+++ b/main.py
@@ -104,12 +104,31 @@ def has_local_image(client, image_name: str) -> bool:
         return False
 
 
+def _force_amd64(base_image: str) -> bool:
+    """
+    Whether to force linux/amd64 when pulling and running an image.
+
+    The legacy rstudio/* images on Docker Hub and their ghcr.io/rstudio/*
+    mirrors are amd64-only, so without an explicit platform pin the pull
+    fails on arm64 hosts with "no matching manifest for linux/arm64/v8".
+    Force the pin for any image under those namespaces.
+
+    Everything else — bakery's modern ghcr.io/posit-dev/* and posit/*
+    images, plus any custom or upstream multi-arch image — trusts
+    Docker's manifest selection to resolve the native architecture.
+    """
+    return base_image.startswith("rstudio/") or base_image.startswith(
+        "ghcr.io/rstudio/"
+    )
+
+
 def pull_image(client, base_image: str, tag: str, quiet: bool) -> None:
     """
     Pull a Docker image from the registry.
 
     Displays progress indicators (dots) unless quiet mode is enabled.
-    Always pulls for linux/amd64 platform for ARM compatibility.
+    Forces linux/amd64 for legacy amd64-only images; lets multi-arch
+    images resolve to the native host architecture.
     """
     image_name = f"{base_image}:{tag}"
 
@@ -118,9 +137,10 @@ def pull_image(client, base_image: str, tag: str, quiet: bool) -> None:
     else:
         print(f"Pulling image {image_name}...", end="", flush=True, file=sys.stderr)
 
-    pull_stream = client.api.pull(
-        base_image, tag=tag, platform="linux/amd64", stream=True, decode=True
-    )
+    pull_kwargs = {"tag": tag, "stream": True, "decode": True}
+    if _force_amd64(base_image):
+        pull_kwargs["platform"] = "linux/amd64"
+    pull_stream = client.api.pull(base_image, **pull_kwargs)
 
     dot_count = 0
     for chunk in pull_stream:
@@ -307,17 +327,19 @@ def main() -> int:
                 key, value = env_var.split("=", 1)
                 container_env[key] = value
 
-    container = client.containers.run(
-        image=image_name,
-        detach=True,
-        tty=True,
-        stdin_open=True,
-        privileged=True,
-        ports={"3939/tcp": args.port},
-        mounts=mounts,
-        platform="linux/amd64",
-        environment=container_env,
-    )
+    run_kwargs = {
+        "image": image_name,
+        "detach": True,
+        "tty": True,
+        "stdin_open": True,
+        "privileged": True,
+        "ports": {"3939/tcp": args.port},
+        "mounts": mounts,
+        "environment": container_env,
+    }
+    if _force_amd64(base_image):
+        run_kwargs["platform"] = "linux/amd64"
+    container = client.containers.run(**run_kwargs)
 
     server_url = f"http://localhost:{args.port}"
     stop_container = True

--- a/test_main.py
+++ b/test_main.py
@@ -124,6 +124,24 @@ def test_get_docker_tag_invalid_format():
     assert main.get_docker_tag("custom-tag") == ("rstudio/rstudio-connect", "custom-tag")
 
 
+def test_force_amd64_legacy_rstudio_images():
+    # Legacy rstudio/* on Docker Hub and ghcr.io/rstudio/* mirrors are
+    # amd64-only and need the pin.
+    assert main._force_amd64("rstudio/rstudio-connect") is True
+    assert main._force_amd64("rstudio/rstudio-connect-preview") is True
+    assert main._force_amd64("ghcr.io/rstudio/rstudio-connect") is True
+    assert main._force_amd64("ghcr.io/rstudio/rstudio-connect-preview") is True
+
+
+def test_force_amd64_modern_images():
+    # Modern ghcr.io/posit-dev/* and posit/* images ship multi-arch
+    # manifests.
+    assert main._force_amd64("ghcr.io/posit-dev/connect") is False
+    assert main._force_amd64("ghcr.io/posit-dev/connect-preview") is False
+    assert main._force_amd64("posit/connect") is False
+    assert main._force_amd64("posit/connect-preview") is False
+
+
 def test_extract_server_version():
     logs = 'time="2025-11-06T13:05:18.626Z" level=info msg="Starting Posit Connect v2025.09.0"'
     assert main.extract_server_version(logs) == "2025.09.0"


### PR DESCRIPTION
The legacy `rstudio/*` Docker Hub images and their `ghcr.io/rstudio/*` mirrors are amd64-only, so without an explicit platform pin the pull fails on arm64 hosts with `no matching manifest for linux/arm64/v8`. Modern `ghcr.io/posit-dev/*` and `posit/*` images ship multi-arch manifests.

Scope the platform pin to `rstudio/` and `ghcr.io/rstudio/` namespaces only. On amd64 hosts behavior is unchanged. On arm64 hosts, modern images now run natively instead of through Rosetta/QEMU emulation.